### PR TITLE
Fixed whitespace bug in port parser that incidentally

### DIFF
--- a/src/tests/detect-parse.c
+++ b/src/tests/detect-parse.c
@@ -16,8 +16,13 @@
  * 02110-1301, USA.
  */
 
+#include "../detect.h"
 #include "../detect-parse.h"
+#include "../detect-engine-port.h"
 #include "../util-unittest.h"
+#include "stdbool.h"
+#include "util-debug.h"
+#include "util-error.h"
 
 /**
  * \test DetectParseTest01 is a regression test against a memory leak
@@ -57,10 +62,190 @@ static int DetectParseTestNoOpt(void)
 }
 
 /**
+ * @brief Convenience method for printing the details of a linked list of DetectPorts
+ *
+ * @param count Index in the linked list
+ *
+ * @param dp Pointer to a DetectPort
+ */
+static void DetectPortPrinter(DetectPort *dp)
+{
+    int count = 0;
+
+    while (dp != NULL) {
+        printf("\n  (DetectPort %d)  flags: %d", count, dp->flags);
+        printf("\n  (DetectPort %d) port: %d", count, dp->port);
+        printf("\n  (DetectPort %d) port2: %d", count, dp->port2);
+        dp = dp->next;
+        count++;
+    }
+}
+
+/**
+ * @brief Convenience method for printing the details of a linked list of Signatures
+ *
+ * @param s Pointer to a Signature
+ */
+static void SigPrinter(Signature *s)
+{
+    printf("\nPRINTING THE SIGNATURE");
+
+    while (s != NULL) {
+        printf("\nnum: %d", s->num);
+        printf("\nflags: %d", s->flags);
+        printf("\ndsize_low: %d", s->dsize_low);
+        printf("\ndsize_high, %d", s->dsize_high);
+
+        printf("\n/** inline -- action */");
+        printf("\naction, %d", s->action);
+        printf("\nfile_flags: %d", s->file_flags);
+
+        printf("\n/** addresses, ports and proto this sig matches on */");
+        printf("\nDetectProto->proto: %hhn", s->proto.proto);
+        printf("\nDetectProto->flags: %d", s->proto.flags);
+
+        printf("\n/** port settings for this signature */");
+        printf("\nSignature->source_ports");
+        DetectPortPrinter(s->sp);
+        printf("\nSignature->destination_ports");
+        DetectPortPrinter(s->dp);
+
+        printf("\nNext Signature? : %s", s->next != NULL ? "true" : "false");
+        if ((s = s->next) != NULL)
+            printf("\nNext Signature...");
+    }
+
+    printf("\nDONE PRINTING\n\n");
+}
+
+// SigParseCleanup
+static void SigParseCleanup(DetectEngineCtx *de_ctx, Signature *s)
+{
+    if (s != NULL)
+        SigFree(de_ctx, s);
+
+    if (de_ctx != NULL)
+        DetectEngineCtxFree(de_ctx);
+}
+
+// InitializeSigParseTest
+static int InitializeSigParseTest(DetectEngineCtx **de_ctx, Signature **s, const char *str)
+{
+    if (!de_ctx || !s) {
+        SCLogError(SC_ERR_INVALID_ARGUMENT, "Error: invalid parameter");
+        return 0;
+    }
+
+    *de_ctx = DetectEngineCtxInit();
+
+    if (*de_ctx) {
+        (*de_ctx)->flags |= DE_QUIET;
+        *s = SigInit(*de_ctx, str);
+        return 1;
+    }
+
+    return 0;
+}
+
+// Tests proper Signature is parsed from portstring length < 16 ie [30:50,!45]
+static int SigParseTestNegatationNoWhitespace(void)
+{
+    int result = 0;
+    DetectEngineCtx *de_ctx = NULL;
+    Signature *s = NULL;
+    const char *str = "alert http any [30:50,!45] -> any [30:50,!45] (msg:\"sid 2 version 0\"; "
+                      "content:\"dummy2\"; sid:2;)";
+
+    if (!InitializeSigParseTest(&de_ctx, &s, str)) {
+        SCLogError(SC_ERR_INVALID_ARGUMENT, "Error");
+        return 0;
+    }
+
+    SigPrinter(s);
+
+    // Assertions
+    if (s->sp->port == 30 && s->sp->port2 == 44 && s->sp->next->port == 46 &&
+            s->sp->next->port2 == 50 && s->sp->next->next == NULL) {
+        result = 1;
+    }
+
+    if (de_ctx && s)
+        SigParseCleanup(de_ctx, s);
+
+    return result;
+}
+
+// // Tests proper Signature is parsed from portstring length < 16 ie [30:50, !45]
+static int SigParseTestWhitespaceLessThan14(void)
+{
+    int result = 0;
+    DetectEngineCtx *de_ctx = NULL;
+    Signature *s = NULL;
+    const char *str = "alert http any [30:50, !45] -> any [30:50,!45] (msg:\"sid 2 version 0\"; "
+                      "content:\"dummy2\"; sid:2;)";
+    if (!InitializeSigParseTest(&de_ctx, &s, str)) {
+        SCLogError(SC_ERR_INVALID_ARGUMENT, "Error");
+        return 0;
+    }
+    SigPrinter(s);
+
+    // Assertions
+    if (s->sp->port == 30 && s->sp->port2 == 44 && s->sp->next->port == 46 &&
+            s->sp->next->port2 == 50 && s->sp->next->next == NULL) {
+        result = 1;
+    }
+
+    if (de_ctx && s) {
+        SigParseCleanup(de_ctx, s);
+    }
+    return result;
+}
+
+// [30:50,              !45] (14 spaces) then you get traffic on ports 30-50 (incorrect)
+static int SigParseTestWhitespace14Spaces(void)
+{
+    DetectEngineCtx *de_ctx = NULL;
+    Signature *s = NULL;
+    const char *str = "alert http any [30:50,              !45] -> any [30:50,!45] (msg:\"sid 2 "
+                      "version 0\"; content:\"dummy2\"; sid:2;)";
+    InitializeSigParseTest(&de_ctx, &s, str);
+    FAIL_IF_NOT_NULL(s);
+    if (de_ctx && s) {
+        SigParseCleanup(de_ctx, s);
+    }
+
+    PASS;
+}
+
+// [30:50,               !45] (more than 14 spaces) you get a parse error failed to parse port " 45"
+// (correct?)
+static int SigParseTestWhitespaceMoreThan14(void)
+{
+    DetectEngineCtx *de_ctx = NULL;
+    Signature *s = NULL;
+    const char *str = "alert http any [30:50,                          !45] -> any [30:50,!45] "
+                      "(msg:\"sid 2 version 0\"; content:\"dummy2\"; sid:2;)";
+
+    InitializeSigParseTest(&de_ctx, &s, str);
+
+    // Assertions
+    FAIL_IF_NOT_NULL(s);
+    if (de_ctx && s) {
+        SigParseCleanup(de_ctx, s);
+    }
+
+    PASS;
+}
+
+/**
  * \brief this function registers unit tests for DetectParse
  */
 void DetectParseRegisterTests(void)
 {
     UtRegisterTest("DetectParseTest01", DetectParseTest01);
     UtRegisterTest("DetectParseTestNoOpt", DetectParseTestNoOpt);
+    UtRegisterTest("SigParseTestNegatationNoWhitespace", SigParseTestNegatationNoWhitespace);
+    UtRegisterTest("SigParseTestWhitespaceLessThan14", SigParseTestWhitespaceLessThan14);
+    UtRegisterTest("SigParseTestWhitespace14Spaces", SigParseTestWhitespace14Spaces);
+    UtRegisterTest("SigParseTestWhitespaceMoreThan14", SigParseTestWhitespaceMoreThan14);
 }


### PR DESCRIPTION
## Notes
### Problem Statement

An off by one error in the detect-engine-port.c was causing negation port strings (everything after the port range) of length 16 to be copied to an array in such a way that the last character was dropped. Example

```
"              45"
```

was interpretted as port 4. Therefore, instead of negating port 45, or failing to parse the rule, Suricata was applying the negation rule to port 4. 

### Solution:

During parsing, send a parsing exception for ports of length 16. Ports with length greater than 16 already send the same exception. 

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable) N/A

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: N/A

Describe changes:
- When parsing ports, the off-by-one exception is being handled by making an assertion about the string length, and defaulting to error state if the port string is >= 16 https://github.com/OISF/suricata/compare/master...drypycode:whitespace-bug#diff-d60d6f0bbed7504f674240e85929fecc6fc5ff161d25155414506e928fb3e3f8R1289

suricata-verify-pr: 829
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
